### PR TITLE
Update install.rdf to fix issue69

### DIFF
--- a/install.rdf
+++ b/install.rdf
@@ -16,6 +16,7 @@
                    em:type="2"
                    em:iconURL="chrome://tabhunter/skin/tabhunter-install.png"
                    em:optionsURL="chrome://tabhunter/content/prefs.xul">
+    <em:multiprocessCompatible>true</em:multiprocessCompatible>
     <em:targetApplication RDF:resource="rdf:#Firefox"/>
   </RDF:Description>
 </RDF:RDF>


### PR DESCRIPTION
 Added the line
   <em:multiprocessCompatible>true</em:multiprocessCompatible>
so that firefox will recognize that tabhunter is compatible with the "e10s" multiprocess mode of firefox.

This is intened to be a resolution of issue69.