### PR TITLE
chore: pretty-print manifest.json from erb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ $(TDIR)/build.sh : build.sh.erb Makefile
 	chmod +x $@
 
 $(TDIR)/manifest.json : manifest.json.erb Makefile
-	TARGET=${TARGET} VERSION=${VERSION} erb -T 2 $< > $@
+	TARGET=${TARGET} VERSION=${VERSION} ruby -rjson -rerb -e 'File.write("$@", JSON.pretty_generate(JSON.parse(ERB.new(File.read("$<"), trim_mode: 2).result)))'
 
 $(TDIR)/popup/browser-polyfill.min.js: popup/browser-polyfill-0.2.1.min.js
 	cp $< $@

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ SOURCES=$(TDIR) $(TBDIR) $(TDIR)/_locales $(TDIR)/_locales/en $(TDIR)/icons $(TD
 		$(TDIR)/popup/prefs.html \
 		$(TDIR)/popup/prefs.js \
 		$(TDIR)/popup/images/restore12.png \
+		$(TDIR)/popup/images/restore24.png \
 		$(TDIR)/popup/tabhunter.css \
 		$(TDIR)/popup/tabhunter.html \
 		$(TDIR)/popup/tabhunter.js
@@ -123,6 +124,9 @@ $(TDIR)/popup/prefs.html: popup/prefs.html.erb popup/_prefs.html.erb Makefile
 	TARGET=${TARGET} VERSION=${VERSION} erb -T 2 $< > $@
 
 $(TDIR)/popup/images/restore12.png: popup/images/restore12.png
+	cp $< $@
+
+$(TDIR)/popup/images/restore24.png: popup/images/restore24.png
 	cp $< $@
 
 tarSource: tabhunter.tgz

--- a/manifest.json.erb
+++ b/manifest.json.erb
@@ -12,9 +12,9 @@ target = ENV['TARGET'] or die("build.sh.erb: TARGET not set") %>{
       "browser_style": true,
 <% end %>
       "default_icon": {
-	"16": "icons/martini-16x16.png",
-	"24": "icons/martini-24x24.png",
-	"32": "icons/martini-32x32.png"
+        "16": "icons/martini-16x16.png",
+        "24": "icons/martini-24x24.png",
+        "32": "icons/martini-32x32.png"
       },
     "default_title": "Tabhunter",
     "default_popup": "popup/tabhunter.html"
@@ -22,9 +22,9 @@ target = ENV['TARGET'] or die("build.sh.erb: TARGET not set") %>{
   "commands": {
     "_execute_browser_action": {
       "suggested_key": {
-	"mac": "MacCtrl+Shift+T",
-	"windows": "Ctrl+Shift+S",
-	"linux": "Ctrl+5"
+        "mac": "MacCtrl+Shift+T",
+        "windows": "Ctrl+Shift+S",
+        "linux": "Ctrl+5"
       }
     }
   },


### PR DESCRIPTION
Minor fix to not rely on the indentation in manifest.json.erb and instead get Ruby to both a) ensure the JSON is valid and parseable and b) to do the pretty-printing of the ERB templated output for consistency.