### PR TITLE
fix: correct comparison against typeof

### DIFF
--- a/popup/tabhunter.js.erb
+++ b/popup/tabhunter.js.erb
@@ -1744,7 +1744,7 @@ function getModifierMask(event) {
 // Things for dealing with searching tabs
 
 function onSearchTextFieldKeyup(event, calledFromInit) {
-    if (typeof(calledFromInit) == undefined) calledFromInit = false;
+    if (typeof(calledFromInit) === "undefined") calledFromInit = false;
     if (event.keyCode == 13 && getModifierMask(event) == 0) {
         event.preventDefault();
         event.stopPropagation();


### PR DESCRIPTION
Flagged by eslint's no-constant-binary-expressions check.

The `typeof` operator always returns a string and so `typeof calledFromInit` could never have equalled undefined (without quotes). It should instead be compared to the string "undefined".