### PR TITLE
Hotfix: Change Windows Default Shortcut

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 TARGET=firefox
-VERSION=3.6.8
+VERSION=3.6.9
 
 TDIR=build/${TARGET}
 TBDIR=$(TDIR)/build

--- a/manifest.json.erb
+++ b/manifest.json.erb
@@ -23,7 +23,7 @@ target = ENV['TARGET'] or die("build.sh.erb: TARGET not set") %>{
     "_execute_browser_action": {
       "suggested_key": {
         "mac": "MacCtrl+Shift+T",
-        "windows": "Ctrl+Shift+S",
+        "windows": "Alt+Shift+S",
         "linux": "Ctrl+5"
       }
     }


### PR DESCRIPTION
# Story

> You can not invoke the shortcut for Tabhunter on Windows

`Ctrl-Shift-S` is Firefox native shortcut for taking a screenshot on Windows -> [Firefox Screenshots](https://support.mozilla.org/en-US/kb/how-do-i-create-screenshot-my-problem#w_firefox-screenshots)

## Bugfix

As _first aid_ workaround, for now just change to a default shortcut that has no conflict with native shortcuts on windows: `Alt+Shift+S`

## Closes

#139 