### PR TITLE
Support for IDN/ITLD sites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 TARGET=firefox
-VERSION=3.6.8
+VERSION=3.6.9
 
 TDIR=build/${TARGET}
 TBDIR=$(TDIR)/build

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ SOURCES=$(TDIR) $(TBDIR) $(TDIR)/_locales $(TDIR)/_locales/en $(TDIR)/icons $(TD
 		$(TDIR)/manifest.json  \
 		$(TDIR)/content/matchText.js \
 		$(TDIR)/popup/jquery-3.5.1.slim.min.js \
+		$(TDIR)/popup/punycode.js \
 		$(TDIR)/popup/prefs.css \
 		$(TDIR)/popup/prefs.html \
 		$(TDIR)/popup/prefs.js \
@@ -97,6 +98,9 @@ $(TDIR)/popup/browser-polyfill.min.js: popup/browser-polyfill-0.2.1.min.js
 	cp $< $@
 
 $(TDIR)/popup/jquery-3.5.1.slim.min.js: popup/jquery-3.5.1.slim.min.js
+	cp $< $@
+
+$(TDIR)/popup/punycode.js: popup/punycode.js
 	cp $< $@
 
 $(TDIR)/content/matchText.js: content/matchText.js.erb

--- a/manifest.json.erb
+++ b/manifest.json.erb
@@ -74,7 +74,11 @@ target = ENV['TARGET'] or die("build.sh.erb: TARGET not set") %>{
 <% if target == 'firefox' %>
   "browser_specific_settings": {
     "gecko": {
+<% if ENV['DEBUG_EXTENSIONS'] %>
+      "id": "tabhunter@<%= ENV['USER'] %>"
+<% else %>
       "id": "tabhunter@ericpromislow.com"
+<% end %>
     }
   },
 <% end %>

--- a/popup/punycode.js
+++ b/popup/punycode.js
@@ -1,0 +1,462 @@
+var punycode = (function() {
+    /** Highest positive signed 32-bit float value */
+    var maxInt = 2147483647; // aka. 0x7FFFFFFF or 2^31-1
+
+    /** Bootstring parameters */
+    var base = 36;
+    var tMin = 1;
+    var tMax = 26;
+    var skew = 38;
+    var damp = 700;
+    var initialBias = 72;
+    var initialN = 128; // 0x80
+    var delimiter = '-'; // '\x2D'
+
+    /** Regular expressions */
+    var regexPunycode = /^xn--/;
+    var regexNonASCII = /[^\x20-\x7E]/; // unprintable ASCII chars + non-ASCII chars
+    var regexSeparators = /[\x2E\u3002\uFF0E\uFF61]/g; // RFC 3490 separators
+
+    /** Error messages */
+    var errors = {
+        'overflow': 'Overflow: input needs wider integers to process',
+        'not-basic': 'Illegal input >= 0x80 (not a basic code point)',
+        'invalid-input': 'Invalid input'
+    };
+
+    /** Convenience shortcuts */
+    var baseMinusTMin = base - tMin;
+    var floor = Math.floor;
+    var stringFromCharCode = String.fromCharCode;
+
+    /*--------------------------------------------------------------------------*/
+
+    /**
+     * A generic error utility function.
+     * @private
+     * @param {String} type The error type.
+     * @returns {Error} Throws a `RangeError` with the applicable error message.
+     */
+    function error(type) {
+        throw new RangeError(errors[type]);
+    }
+
+    /**
+     * A generic `Array#map` utility function.
+     * @private
+     * @param {Array} array The array to iterate over.
+     * @param {Function} callback The function that gets called for every array
+     * item.
+     * @returns {Array} A new array of values returned by the callback function.
+     */
+    function map(array, fn) {
+        var result = [];
+        var length = array.length;
+        while (length--) {
+            result[length] = fn(array[length]);
+        }
+        return result;
+    }
+
+    /**
+     * A simple `Array#map`-like wrapper to work with domain name strings or email
+     * addresses.
+     * @private
+     * @param {String} domain The domain name or email address.
+     * @param {Function} callback The function that gets called for every
+     * character.
+     * @returns {Array} A new string of characters returned by the callback
+     * function.
+     */
+    function mapDomain(string, fn) {
+        var parts = string.split('@');
+        var result = '';
+        if (parts.length > 1) {
+            // In email addresses, only the domain name should be punycoded. Leave
+            // the local part (everything up to `@`) intact.
+            result = parts[0] + '@';
+            string = parts[1];
+        }
+        // Avoid `split(regex)` for IE8 compatibility. See #17.
+        string = string.replace(regexSeparators, '\x2E');
+        var labels = string.split('.');
+        var encoded = map(labels, fn).join('.');
+        return result + encoded;
+    }
+
+    /**
+     * Creates an array containing the numeric code points of each Unicode
+     * character in the string. While JavaScript uses UCS-2 internally,
+     * this function will convert a pair of surrogate halves (each of which
+     * UCS-2 exposes as separate characters) into a single code point,
+     * matching UTF-16.
+     * @see `punycode.ucs2.decode`
+     * @see <https://mathiasbynens.be/notes/javascript-encoding>
+     * @memberOf punycode.ucs2
+     * @name decode
+     * @param {String} string The Unicode input string (e.g. 'Manuel Quiñones').
+     * @returns {Array} The new array of code points.
+     */
+    function ucs2decode(string) {
+        var output = [];
+        var counter = 0;
+        var length = string.length;
+        var value;
+        var extra;
+        while (counter < length) {
+            value = string.charCodeAt(counter++);
+            if (value >= 0xD800 && value <= 0xDBFF && counter < length) {
+                // high surrogate, and there is a next character
+                extra = string.charCodeAt(counter++);
+                if ((extra & 0xFC00) == 0xDC00) { // low surrogate
+                    output.push(((value & 0x3FF) << 10) + (extra & 0x3FF) + 0x10000);
+                } else {
+                    // unmatched surrogate; only append this code unit, in case the next
+                    // code unit is the high surrogate of a surrogate pair
+                    output.push(value);
+                    counter--;
+                }
+            } else {
+                output.push(value);
+            }
+        }
+        return output;
+    }
+
+    /**
+     * Creates a string based on an array of numeric code points.
+     * @see `punycode.ucs2.encode`
+     * @memberOf punycode.ucs2
+     * @name encode
+     * @param {Array} codePoints The array of numeric code points.
+     * @returns {String} The new Unicode string.
+     */
+    function ucs2encode(array) {
+        return map(array, function(value) {
+            var output = '';
+            if (value > 0xFFFF) {
+                value -= 0x10000;
+                output += stringFromCharCode(value >>> 10 & 0x3FF | 0xD800);
+                value = 0xDC00 | value & 0x3FF;
+            }
+            output += stringFromCharCode(value);
+            return output;
+        }).join('');
+    }
+
+    /**
+     * Converts a basic code point into a digit/integer.
+     * @see `digitToBasic()`
+     * @private
+     * @param {Number} codePoint The basic code point.
+     * @returns {Number} The numeric value of a basic code point (for use in
+     * representing integers) in the range `0` to `base - 1`, or `base` if
+     * the code point does not represent a value.
+     */
+    function basicToDigit(codePoint) {
+        if (codePoint - 48 < 10) {
+            return codePoint - 22;
+        }
+        if (codePoint - 65 < 26) {
+            return codePoint - 65;
+        }
+        if (codePoint - 97 < 26) {
+            return codePoint - 97;
+        }
+        return base;
+    }
+
+    /**
+     * Converts a digit/integer into a basic code point.
+     * @see `basicToDigit()`
+     * @private
+     * @param {Number} digit The numeric value of a basic code point.
+     * @returns {Number} The basic code point whose value (when used for
+     * representing integers) is `digit`, which needs to be in the range
+     * `0` to `base - 1`. If `flag` is non-zero, the uppercase form is
+     * used.
+     */
+    function digitToBasic(digit, flag) {
+        //  0..25 map to ASCII a..z or A..Z
+        // 26..35 map to ASCII 0..9
+        return digit + 22 + 75 * (digit < 26) - ((flag != 0) << 5);
+    }
+
+    /**
+     * Bias adaptation function as per section 3.4 of RFC 3492.
+     * http://tools.ietf.org/html/rfc3492#section-3.4
+     * @private
+     */
+    function adapt(delta, numPoints, firstTime) {
+        var k = 0;
+        delta = firstTime ? floor(delta / damp) : delta >> 1;
+        delta += floor(delta / numPoints);
+        for (/* no initialization */; delta > baseMinusTMin * tMax >> 1; k += base) {
+            delta = floor(delta / baseMinusTMin);
+        }
+        return floor(k + (baseMinusTMin + 1) * delta / (delta + skew));
+    }
+
+    /**
+     * Converts a Punycode string of ASCII-only symbols to a string of Unicode
+     * symbols.
+     * @memberOf punycode
+     * @param {String} input The Punycode string of ASCII-only symbols.
+     * @returns {String} The resulting string of Unicode symbols.
+     */
+    function decode(input) {
+        // Don't use UCS-2
+        var output = [];
+        var inputLength = input.length;
+        var i = 0;
+        var n = initialN;
+        var bias = initialBias;
+
+        // Handle the basic code points: let `basic` be the number of input code
+        // points before the last delimiter, or `0` if there is none, then copy
+        // the first `basic` code points to the output.
+
+        var basic = input.lastIndexOf(delimiter);
+        if (basic < 0) {
+            basic = 0;
+        }
+
+        for (var j = 0; j < basic; ++j) {
+            // if it's not a basic code point
+            if (input.charCodeAt(j) >= 0x80) {
+                error('not-basic');
+            }
+            output.push(input.charCodeAt(j));
+        }
+
+        // Main decoding loop: start just after the last delimiter if any basic code
+        // points were copied; start at the beginning otherwise.
+
+        for (var index = basic > 0 ? basic + 1 : 0; index < inputLength; /* no final expression */) {
+
+            // `index` is the index of the next character to be consumed.
+            // Decode a generalized variable-length integer into `delta`,
+            // which gets added to `i`. The overflow checking is easier
+            // if we increase `i` as we go, then subtract off its starting
+            // value at the end to obtain `delta`.
+            var oldi = i;
+            for (var w = 1, k = base; /* no condition */; k += base) {
+
+                if (index >= inputLength) {
+                    error('invalid-input');
+                }
+
+                var digit = basicToDigit(input.charCodeAt(index++));
+
+                if (digit >= base || digit > floor((maxInt - i) / w)) {
+                    error('overflow');
+                }
+
+                i += digit * w;
+                var t = k <= bias ? tMin : (k >= bias + tMax ? tMax : k - bias);
+
+                if (digit < t) {
+                    break;
+                }
+
+                var baseMinusT = base - t;
+                if (w > floor(maxInt / baseMinusT)) {
+                    error('overflow');
+                }
+                w *= baseMinusT;
+
+            }
+
+            var out = output.length + 1;
+            bias = adapt(i - oldi, out, oldi == 0);
+
+            // `i` was supposed to wrap around from `out` to `0`,
+            // incrementing `n` each time, so we'll fix that now:
+            if (floor(i / out) > maxInt - n) {
+                error('overflow');
+            }
+
+            n += floor(i / out);
+            i %= out;
+
+            // Insert `n` at position `i` of the output
+            output.splice(i++, 0, n);
+
+        }
+
+        return ucs2encode(output);
+    }
+
+    /**
+     * Converts a string of Unicode symbols (e.g. a domain name label) to a
+     * Punycode string of ASCII-only symbols.
+     * @memberOf punycode
+     * @param {String} input The string of Unicode symbols.
+     * @returns {String} The resulting Punycode string of ASCII-only symbols.
+     */
+    function encode(input) {
+        var n;
+        var delta;
+        var h;
+        var b;
+        var bias;
+        var j;
+        var m;
+        var q;
+        var k;
+        var t;
+        var currentValue;
+        var output = [];
+
+        // Convert the input in UCS-2 to Unicode
+        input = ucs2decode(input);
+
+        // Cache the length
+        var inputLength = input.length;
+
+        // Initialize the state
+        n = initialN;
+        delta = 0;
+        bias = initialBias;
+
+        // Handle the basic code points
+        for (j = 0; j < inputLength; ++j) {
+            currentValue = input[j];
+            if (currentValue < 0x80) {
+                output.push(stringFromCharCode(currentValue));
+            }
+        }
+
+        h = b = output.length;
+
+        // `b` is the number of basic code points in the input, which is also the
+        // number of code points in the output so far.
+
+        if (b < inputLength) {
+            output.push(delimiter);
+        }
+
+        // Main encoding loop:
+        while (h < inputLength) {
+            // All non-basic code points < n have been handled already. Find the next
+            // larger one:
+            for (m = maxInt, j = 0; j < inputLength; ++j) {
+                currentValue = input[j];
+                if (currentValue >= n && currentValue < m) {
+                    m = currentValue;
+                }
+            }
+
+            // Increase `delta` enough to advance the decoder's <n,i> state to <m,0>,
+            // but guard against overflow
+            var handledCPCount = h + 1;
+            if (m - n > floor((maxInt - delta) / handledCPCount)) {
+                error('overflow');
+            }
+
+            delta += (m - n) * handledCPCount;
+            n = m;
+
+            for (j = 0; j < inputLength; ++j) {
+                currentValue = input[j];
+
+                if (currentValue < n && ++delta > maxInt) {
+                    error('overflow');
+                }
+
+                if (currentValue == n) {
+                    // Represent delta as a generalized variable-length integer
+                    for (q = delta, k = base; /* no condition */; k += base) {
+                        t = k <= bias ? tMin : (k >= bias + tMax ? tMax : k - bias);
+                        if (q < t) {
+                            break;
+                        }
+                        var qMinusT = q - t;
+                        var baseMinusT = base - t;
+                        output.push(
+                            stringFromCharCode(digitToBasic(t + qMinusT % baseMinusT, 0))
+                        );
+                        q = floor(qMinusT / baseMinusT);
+                    }
+
+                    output.push(stringFromCharCode(digitToBasic(q, 0)));
+                    bias = adapt(delta, handledCPCount, h == b);
+                    delta = 0;
+                    ++h;
+                }
+            }
+
+            ++delta;
+            ++n;
+
+        }
+        return output.join('');
+    }
+
+    /**
+     * Converts a Punycode string representing a domain name or an email address
+     * to Unicode. Only the Punycoded parts of the input will be converted, i.e.
+     * it doesn't matter if you call it on a string that has already been
+     * converted to Unicode.
+     * @memberOf punycode
+     * @param {String} input The Punycoded domain name or email address to
+     * convert to Unicode.
+     * @returns {String} The Unicode representation of the given Punycode
+     * string.
+     */
+    function toUnicode(input) {
+        return mapDomain(input, function(string) {
+            return regexPunycode.test(string)
+                ? decode(string.slice(4).toLowerCase())
+                : string;
+        });
+    }
+
+    /**
+     * Converts a Unicode string representing a domain name or an email address to
+     * Punycode. Only the non-ASCII parts of the domain name will be converted,
+     * i.e. it doesn't matter if you call it with a domain that's already in
+     * ASCII.
+     * @memberOf punycode
+     * @param {String} input The domain name or email address to convert, as a
+     * Unicode string.
+     * @returns {String} The Punycode representation of the given domain name or
+     * email address.
+     */
+    function toASCII(input) {
+        return mapDomain(input, function(string) {
+            return regexNonASCII.test(string)
+                ? 'xn--' + encode(string)
+                : string;
+        });
+    }
+
+    /*--------------------------------------------------------------------------*/
+
+    /** Define the public API */
+    var punycode = {
+        /**
+         * A string representing the current Punycode.js version number.
+         * @memberOf punycode
+         * @type String
+         */
+        'version': '2.1.0',
+        /**
+         * An object of methods to convert from JavaScript's internal character
+         * representation (UCS-2) to Unicode code points, and back.
+         * @see <https://mathiasbynens.be/notes/javascript-encoding>
+         * @memberOf punycode
+         * @type Object
+         */
+        'ucs2': {
+            'decode': ucs2decode,
+            'encode': ucs2encode
+        },
+        'decode': decode,
+        'encode': encode,
+        'toASCII': toASCII,
+        'toUnicode': toUnicode
+    };
+
+    return punycode;
+}());

--- a/popup/tabhunter.html.erb
+++ b/popup/tabhunter.html.erb
@@ -9,6 +9,7 @@
 <% if ENV['TARGET'] == 'chrome' %>
     <script src="browser-polyfill.min.js"></script>
 <% end %>
+    <script src="punycode.js"></script>
     <script src="tabhunter.js"></script>
     <script src="prefs.js"></script>
   </head>

--- a/popup/tabhunter.js.erb
+++ b/popup/tabhunter.js.erb
@@ -345,9 +345,21 @@ var windowCounter = new WindowIndexThing();
 // Tabs: save [title, url, window#id, tab#id, tab#index, tab#favIconUrl, tab#audible] 
 function makeTabItem(id, tab) {
     windowCounter.intern(id);
+    let searchableUrl = tab.url;
+    if (tab.url) {
+        try {
+            let urlObject = new URL(tab.url);
+            if (urlObject.hostname.includes('xn--')) {
+                searchableUrl = tab.url.replace(urlObject.hostname, punycode.toUnicode(urlObject.hostname));
+            }
+        } catch (e) {
+            // ignore, probably not a punycode url or invalid url
+        }
+    }
     return {
       title: tab.title,
       url: tab.url,
+      searchableUrl: searchableUrl,
       windowID: id,
       tabID: tab.id,
       tabIndex: tab.index,
@@ -673,7 +685,7 @@ function processArrowKey_aux(event) {
     }
     selectedIndex = newSelectedIndex;
     var url = document.getElementById("url");
-    url.value = items[matchedItems[selectedIndex]].url;
+    url.value = items[matchedItems[selectedIndex]].searchableUrl;
     li.scrollIntoView({ block: 'nearest', inline: 'nearest' });
 }
 
@@ -691,7 +703,7 @@ function onListItemClick(event) {
     }
     selectedIndex = i;
     lastClickedIndex = (mask & (SHIFT_KEY|CTRL_KEY)) == 0 ? i : -1;
-    document.getElementById("url").value = items[matchedItems[i]].url;
+    document.getElementById("url").value = items[matchedItems[i]].searchableUrl;
     updateButtons();
 }
 
@@ -791,7 +803,7 @@ function buildMatchedItemsArray(pattern) {
                 ptn = new RegExp(pattern, "i");
             }
             fn = function matchPtn(item) {
-                const match = ptn.test(item.title) || ptn.test(item.url);
+                const match = ptn.test(item.title) || ptn.test(item.searchableUrl);
                 if (negate) {
                     return !match
                 }
@@ -804,7 +816,7 @@ function buildMatchedItemsArray(pattern) {
             ptn = pattern.toLowerCase();
             fn = function matchText(item) {
               return (
-                item.title.toLowerCase().includes(ptn) || item.url.toLowerCase().includes(ptn)
+                item.title.toLowerCase().includes(ptn) || item.searchableUrl.toLowerCase().includes(ptn)
               );
             };
         }
@@ -888,7 +900,7 @@ ListBuilder.prototype = {
             } else {
                 el.textContent = '';
             }
-            el.textContent += item.title + " - " + item.url;
+            el.textContent += item.title + " - " + item.searchableUrl;
             if (sortBy == compareByNeglect
                 <% if ENV['TARGET'] == 'chrome' %>
                 && g_itemSupportsLastAccessed
@@ -915,7 +927,7 @@ ListBuilder.prototype = {
                 let prevItem = items[prevIdx];
                 // Tabs might have url='about:blank' if they're neglected and
                 // haven't been reloaded after a restart...
-                if (prevItem.url == item.url && prevItem.title == item.title) {
+                if (prevItem.searchableUrl == item.searchableUrl && prevItem.title == item.title) {
                     $(el).addClass("duplicate");
                     el.textContent = el.textContent + " [DUP]";
                 }
@@ -984,7 +996,7 @@ function onTablistDragStartHandler(event) {
         selectedItems.forEach(function(selectedItem) {
             let index = selectedItem.actualIndex;
             indices.push(index);
-            urls.push(items[index].url);
+            urls.push(items[index].searchableUrl);
         });
         // Add the drag data
         event.dataTransfer.setData("text/plain", indices.join(","));
@@ -1249,11 +1261,11 @@ function updateURL() {
     var selectedItems = getSelectedItemsJQ();
     if (selectedItems.length >= 1) {
         var index = selectedItems[0].actualIndex;
-        url.value = items[index].url;
+        url.value = items[index].searchableUrl;
         return;
     }
     if (matchedItems.length == 1) {
-        url.value = items[matchedItems[0]].url;
+        url.value = items[matchedItems[0]].searchableUrl;
     } else {
         url.value = "";
     }
@@ -1366,7 +1378,7 @@ function setClipboard(text) {
 }
 
 function doCopyURLButton() {
-    var text = gatherText(function(item) { return item.url; });
+    var text = gatherText(function(item) { return item.searchableUrl; });
     setClipboard(text);
 }
 
@@ -1376,7 +1388,7 @@ function doCopyTitleButton() {
 }
 
 function doCopyURLTitleButton() {
-    var text = gatherText(function(item) { return item.url + ' | ' + item.title; });
+    var text = gatherText(function(item) { return item.searchableUrl + ' | ' + item.title; });
     setClipboard(text);
 }
 
@@ -1707,7 +1719,7 @@ function doMoveToBookmarkButton() {
     let targetBookmarkID = options.item(0).value;
     let selectedItems = getSelectedItemsJQ();
     let itemsToMove = selectedItems.map(function(selectedItem) { return items[selectedItem.actualIndex]; });
-    let urls = itemsToMove.map(function(item) { return item.url; });
+    let urls = itemsToMove.map(function(item) { return item.searchableUrl; });
         let index = -1;
         var reportErr, moveNextURL;
     reportErr = function(err) {

--- a/popup/tabhunter.js.erb
+++ b/popup/tabhunter.js.erb
@@ -1249,7 +1249,7 @@ function updateURL() {
     var selectedItems = getSelectedItemsJQ();
     if (selectedItems.length >= 1) {
         var index = selectedItems[0].actualIndex;
-        URL.value = items[index].url;
+        url.value = items[index].url;
         return;
     }
     if (matchedItems.length == 1) {


### PR DESCRIPTION
The problem in #129 was that the browser provides URLs with IDNs in their Punycode format (e.g., xn--...), but users search for them using Unicode characters (e.g., https://наполеон.гафгаф.рф, https://моника.гафгаф.рф, https://q.терлецкая-дубрава.рф, https://n.терлецкая-дубрава.рф, https://s.терлецкая-дубрава.рф … ). 

Solution was to create a new, "searchable" version of each URL and use it throughout the extension for searching and display.

I am testing it in my regular browsing with Firefox, IDN support looks great

<img width="624" height="402" alt="image" src="https://github.com/user-attachments/assets/64caaeed-1154-45d0-9434-63c61737eec5" />

and nothing broken in regular sites

<img width="612" height="407" alt="image" src="https://github.com/user-attachments/assets/325189b8-300a-412d-8cdd-aa63c619f4ae" />

----


- In `makeTabItem` created a "Searchable URL" —  human-readable version of URL for each tab
URL. If the hostname contains `xn--`, it calls `punycode.toUnicode()` to convert the Punycode hostname into readable Unicode characters. The original `tab.url` is preserved for internal browser interactions.

- update Search and Filtering Logic in `buildMatchedItemsArray`

- Consistent update the UI & business logic (`url` → `searchableUrl`)
    - `makeListFromMatchedItems`
    - `onListItemClick`
    - `processArrowKey_aux`                               - `updateURL`
    - `doCopyURLButton`
    - `doCopyURLTitleButton` 
    - `onTablistDragStartHandler`
    - `doMoveToBookmarkButton`
    - `makeListFromMatchedItems`

- Also, it looks I find a typo → https://github.com/ericpromislow/tabhunter/commit/6ec1ac00684b771c7995a1dc31428fdec75c5a07 and propose small change to simplify development/debugging



